### PR TITLE
Allow serial console resize to beyond 80 columns.

### DIFF
--- a/virtManager/details/serialcon.py
+++ b/virtManager/details/serialcon.py
@@ -273,7 +273,7 @@ class vmmSerialConsole(vmmGObject):
 
         if self._vteterminal:
             scrollbar.set_adjustment(self._vteterminal.get_vadjustment())
-            align.add(self._vteterminal)
+            align.pack_start(self._vteterminal, True, True, 0)
 
         evbox.add(align)
         terminalbox.pack_start(evbox, True, True, 0)


### PR DESCRIPTION
Replace Gtk.Box.add() with Gtk.Box.pack_start() to place the VTE terminal widget. This enables horizontal expansion/filling the terminal widget when resizing the serial console window.

The original code works on Fedora but fails on Debian-based distros. To test: enlarge the window beyond 80 columns and run the `resize` command. Run `stty -a` to see the new dimensions.